### PR TITLE
Change logo src to https to avoid mixed-content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![Haxl Logo](http://github.com/facebook/Haxl/raw/master/logo.png)
+![Haxl Logo](https://github.com/facebook/Haxl/raw/master/logo.png)
 
 # Haxl
 


### PR DESCRIPTION
```
The page at 'https://github.com/oreoshake/Haxl' was loaded over HTTPS, but displayed insecure content from 'http://github.com/facebook/Haxl/raw/master/logo.png': this content should also be loaded over HTTPS.

curl https://raw.githubusercontent.com/facebook/Haxl/master/logo.png 200OK
```
