### PR TITLE
Small SQL example .cabal fixes

### DIFF
--- a/example/sql/haxl-example.cabal
+++ b/example/sql/haxl-example.cabal
@@ -1,4 +1,6 @@
 cabal-version: >=1.8
+name: haxl-example
+version: 0.1.0.0
 executable example
   main-is:
     Main.hs
@@ -6,4 +8,5 @@ executable example
     hashable,
     haxl,
     text,
-    random
+    random,
+    base


### PR DESCRIPTION
When building from a fresh sandbox in /example/sql, cabal complained
about the name and version fields missing, as well as the base
dependency missing in build-depends.
