### PR TITLE
Updated License

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/DataCache.hs
+++ b/Haxl/Core/DataCache.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Exception.hs
+++ b/Haxl/Core/Exception.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/RequestStore.hs
+++ b/Haxl/Core/RequestStore.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Show1.hs
+++ b/Haxl/Core/Show1.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/StateStore.hs
+++ b/Haxl/Core/StateStore.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Types.hs
+++ b/Haxl/Core/Types.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Util.hs
+++ b/Haxl/Core/Util.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Prelude.hs
+++ b/Haxl/Prelude.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,


### PR DESCRIPTION
In following commits, "Copyright (c) 2014, Facebook, Inc." is replaced to "Copyright (c) 2015, Facebook, Inc.". Change of year, in the copyright notice.