### PR TITLE
Addition of year 2015, in the copyright notice.

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/DataCache.hs
+++ b/Haxl/Core/DataCache.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Exception.hs
+++ b/Haxl/Core/Exception.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/RequestStore.hs
+++ b/Haxl/Core/RequestStore.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Show1.hs
+++ b/Haxl/Core/Show1.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/StateStore.hs
+++ b/Haxl/Core/StateStore.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Types.hs
+++ b/Haxl/Core/Types.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Core/Util.hs
+++ b/Haxl/Core/Util.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/Haxl/Prelude.hs
+++ b/Haxl/Prelude.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2014, Facebook, Inc.
+-- Copyright (c) 2014 - 2015, Facebook, Inc.
 -- All rights reserved.
 --
 -- This source code is distributed under the terms of a BSD license,

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Facebook, Inc.
+Copyright (c) 2014 - 2015, Facebook, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/example/facebook/LICENSE
+++ b/example/facebook/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Facebook, Inc.
+Copyright (c) 2014 - 2015, Facebook, Inc.
 
 All rights reserved.
 


### PR DESCRIPTION
In following commits, "Copyright (c) 2014, Facebook, Inc." is replaced with "Copyright (c) 2014 - 2015, Facebook, Inc.". Change of year, in the copyright notice.

Undertaken following considerations 
 - using plurals in years, 
 - consolidated PR for 12 commits, 
 - license file updated, and 
 - checked for need in updating other files in all directories.

Hope this PR can be considered.