### PR TITLE
Bounded cache

### DIFF
--- a/Haxl/Core/FiniteCache.hs
+++ b/Haxl/Core/FiniteCache.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{- |
+Module: Haxl.Core.FiniteCache
+Description: A bounded cache for a specific type of request
+
+The cache is built upon a priority queue from the psqueues package.
+
+HashPSQ from that package uses Ord for resolving hash collisions, so
+we cannot use it without imposing an Ord instance for the requests.
+
+Instead, each hash bucket is a linked list, sorted by
+priority (highest first). Because of monotony (a newly inserted value
+always has highest prioroty), this is easy to enforce.
+
+The design of the cache loosely follows the nice blog post by Jasper Van
+der Jeugt, http://jaspervdj.be/posts/2015-02-24-lru-cache.html.
+-}
+
+module Haxl.Core.FiniteCache
+       where
+
+import           Data.Hashable
+import           Data.Int      (Int64)
+import qualified Data.IntPSQ   as IntPSQ
+import           Data.Maybe
+
+type Priority = Int64
+
+-- | Strict tuple of priority, key, and value.
+data PV k v = PV !Priority !k !v
+              deriving Show
+
+-- | A hash bucket. Values with the same hash are stored in a list,
+-- where the value of highest priority is always at the front.
+data Bucket k v = Bucket [PV k v]
+                  deriving Show
+
+data FiniteCache k v =
+  FiniteCache { cCapacity :: !(Maybe Int)
+                -- ^ Capacity of the subcache. Nothing means unbounded
+              , cSize     :: !Int
+                -- ^ Current size
+              , cTick     :: !Priority
+                -- ^ Priority of the next value inserted
+              , cQueue    :: !(IntPSQ.IntPSQ Priority (Bucket k v))
+                -- ^ priority queue storing the actual values.
+                --
+                --   The priority of a bucket is the priority of its
+                --   highest-priority value.
+              } deriving Show
+
+-- | Initialisation of an empty 'FiniteCache'.
+empty :: Maybe Int -> FiniteCache k v
+empty capacity
+  | isJust capacity && ((<0) . fromJust) capacity =
+    error "FiniteCache.empty: negative capacity."
+  | otherwise =
+    FiniteCache { cCapacity = capacity
+                , cSize = 0
+                , cTick = 0
+                , cQueue = IntPSQ.empty
+                }
+
+-- | Delete the value with minimal priority.
+deleteMin :: FiniteCache k v -> FiniteCache k v
+deleteMin sc@FiniteCache {..}
+  | IntPSQ.null cQueue = sc
+  | otherwise =
+    let (_, cQueue') = IntPSQ.alterMin f cQueue
+    in FiniteCache { cCapacity = cCapacity
+                , cSize = cSize - 1
+                , cTick = cTick
+                , cQueue = cQueue'
+                }
+  where
+    f Nothing = error "FiniteCache.deleteMin: non-empty cache without minimal element"
+    -- if the bucket contains only one value, it is deleted
+    f (Just (_, _, Bucket [_])) = (Nothing, Nothing)
+    -- if there are more values, the last one is discarded.
+    -- Note that this dos not change the priority of the bucket.
+    f (Just (k, p, Bucket pvs)) = (Nothing, Just (k, p, Bucket (init pvs)))
+
+-- | Make sure the cache does not exceed its capacity.
+trim :: FiniteCache k v -> FiniteCache k v
+trim sc
+  -- In case of a capacity overflow, just restart with an empty
+  -- cache.  It's the simplest thing to do, and an overflow
+  -- should be a rare event.
+  | cTick sc == maxBound = empty (cCapacity sc)
+  -- Don't trim unbounded caches.
+  | isNothing $ cCapacity sc = sc
+  -- Remove element of least priority when full
+  | cSize sc > fromJust (cCapacity sc) = deleteMin sc
+  | otherwise = sc
+
+insert :: (Hashable k, Eq k)
+          => k
+          -> v
+          -> FiniteCache k v
+          -> FiniteCache k v
+insert k v FiniteCache {..} =
+  let (cSize', cQueue') = IntPSQ.alter f (hash k) cQueue
+  in trim FiniteCache { cCapacity = cCapacity
+                      , cSize = cSize'
+                      , cTick = cTick + 1
+                      , cQueue = cQueue'
+                      }
+  where
+    -- no bucket for that hash yet, create one
+    pv = PV cTick k v
+    f Nothing = (cSize + 1, Just (cTick, Bucket [pv]))
+    f (Just (_, Bucket b)) =
+      case break (\ (PV _ k' _) -> k' == k ) b of
+        -- request is not yet cached
+        (xs,[]) -> (cSize + 1, Just (cTick, Bucket (pv:xs)))
+        -- request had already been cached, update it
+        (xs, xs') -> (cSize, Just (cTick, Bucket (pv:(xs++tail xs'))))
+
+lookup :: (Hashable k, Eq k)
+          => k
+          -> FiniteCache k v
+          -> Maybe (v, FiniteCache k v)
+lookup k FiniteCache {..} =
+  case IntPSQ.alter f (hash k) cQueue
+  of (Just v, cQueue') -> Just (v, FiniteCache { cCapacity = cCapacity
+                                                , cSize = cSize
+                                                , cQueue = cQueue'
+                                                , cTick = cTick + 1})
+     (Nothing, _) -> Nothing
+  where
+    f Nothing = (Nothing, Nothing)
+    f (Just (p, Bucket b)) =
+      case break (\ (PV _ k' _) -> k' == k ) b of
+          (_, []) ->  (Nothing, Just (p, Bucket b))
+          (xs, PV _ k' v:xs') ->
+            ( Just v
+            , Just (cTick, Bucket $ PV cTick k' v:(xs ++ xs')))
+
+toList :: FiniteCache k v -> [(k, v)]
+toList FiniteCache { cQueue = cq } = IntPSQ.fold' f [] cq
+  where f _ _ (Bucket b) acc = map (\ (PV _ k v) -> (k, v) ) b ++ acc

--- a/Haxl/Core/Types.hs
+++ b/Haxl/Core/Types.hs
@@ -44,6 +44,7 @@ module Haxl.Core.Types (
   -- * Data fetching
   DataSource(..),
   DataSourceName(..),
+  CacheableSource(..),
   Request,
   BlockedFetch(..),
   PerformFetch(..),
@@ -220,6 +221,11 @@ class DataSourceName req where
   -- take a dummy request.
   dataSourceName :: req a -> Text
 
+class CacheableSource req where
+  -- | Maximum number of items of a particular request in the cache.
+  -- If 'Nothing', the cache is unbounded for this request type.
+  cacheSize :: req a -> Maybe Int
+
 -- The 'Show1' class is a workaround for the fact that we can't write
 -- @'Show' (req a)@ as a superclass of 'DataSource', without also
 -- parameterizing 'DataSource' over @a@, which is a pain (I tried
@@ -231,8 +237,12 @@ type Request req a =
   ( Eq (req a)
   , Hashable (req a)
   , Typeable (req a)
+    -- See comment at DataCache.insert
+  , Typeable req
+  , Typeable a
   , Show (req a)
   , Show a
+  , CacheableSource req
   )
 
 -- | A data source can fetch data in one of two ways.

--- a/Haxl/Core/Types.hs
+++ b/Haxl/Core/Types.hs
@@ -223,8 +223,14 @@ class DataSourceName req where
 
 class CacheableSource req where
   -- | Maximum number of items of a particular request in the cache.
-  -- If 'Nothing', the cache is unbounded for this request type.
+  --
+  -- If 'Nothing', the cache is unbounded for this request type. This is the default.
+  --
+  -- Please note that the cache in Haxl, in addition to boosting
+  -- performance, also guarantees consistency and replayability when
+  -- data sources change. Choosing a bounded cache sacrifices this.
   cacheSize :: req a -> Maybe Int
+  cacheSize _ = Nothing
 
 -- The 'Show1' class is a workaround for the fact that we can't write
 -- @'Show' (req a)@ as a superclass of 'DataSource', without also

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -38,12 +38,14 @@ library
     text >= 1.1.0.1 && < 1.3,
     time >= 1.4 && < 1.6,
     unordered-containers == 0.2.*,
-    vector == 0.10.*
+    vector == 0.10.*,
+    psqueues >= 0.2.0.2
 
   exposed-modules:
     Haxl.Core,
     Haxl.Core.DataCache,
     Haxl.Core.Exception,
+    Haxl.Core.FiniteCache,
     Haxl.Core.Monad,
     Haxl.Core.RequestStore,
     Haxl.Core.StateStore,

--- a/tests/DataCacheTest.hs
+++ b/tests/DataCacheTest.hs
@@ -21,8 +21,7 @@ deriving instance Show (TestReq a)
 instance Hashable (TestReq a) where
   hashWithSalt salt (Req i) = hashWithSalt salt i
 
-instance CacheableSource TestReq where
-  cacheSize _ = Nothing
+instance CacheableSource TestReq
 
 dcSoundnessTest :: Test
 dcSoundnessTest = TestLabel "DataCache soundness" $ TestCase $ do

--- a/tests/ExampleDataSource.hs
+++ b/tests/ExampleDataSource.hs
@@ -83,8 +83,7 @@ instance StateKey ExampleReq where
 instance DataSourceName ExampleReq where
   dataSourceName _ = "ExampleDataSource"
 
-instance CacheableSource ExampleReq where
-  cacheSize _ = Nothing
+instance CacheableSource ExampleReq
 
 -- Next we need to define an instance of DataSource:
 

--- a/tests/ExampleDataSource.hs
+++ b/tests/ExampleDataSource.hs
@@ -83,6 +83,9 @@ instance StateKey ExampleReq where
 instance DataSourceName ExampleReq where
   dataSourceName _ = "ExampleDataSource"
 
+instance CacheableSource ExampleReq where
+  cacheSize _ = Nothing
+
 -- Next we need to define an instance of DataSource:
 
 instance DataSource u ExampleReq where

--- a/tests/LoadCache.txt
+++ b/tests/LoadCache.txt
@@ -1,5 +1,5 @@
 loadCache :: GenHaxl u ()
 loadCache = do
-  cacheRequest (CountAardvarks "yyy") (except (LogicError (NotFound "yyy")))
   cacheRequest (CountAardvarks "xxx") (Right (3))
+  cacheRequest (CountAardvarks "yyy") (except (LogicError (NotFound "yyy")))
   cacheRequest (ListWombats 100) (Right ([1,2,3]))

--- a/tests/MockTAO.hs
+++ b/tests/MockTAO.hs
@@ -47,6 +47,9 @@ instance StateKey TAOReq where
 instance DataSourceName TAOReq where
   dataSourceName _ = "MockTAO"
 
+instance CacheableSource TAOReq where
+  cacheSize _ = Nothing
+
 instance DataSource UserEnv TAOReq where
   fetch _state _flags _user bfs = SyncFetch $ mapM_ doFetch bfs
 

--- a/tests/MockTAO.hs
+++ b/tests/MockTAO.hs
@@ -47,8 +47,7 @@ instance StateKey TAOReq where
 instance DataSourceName TAOReq where
   dataSourceName _ = "MockTAO"
 
-instance CacheableSource TAOReq where
-  cacheSize _ = Nothing
+instance CacheableSource TAOReq
 
 instance DataSource UserEnv TAOReq where
   fetch _state _flags _user bfs = SyncFetch $ mapM_ doFetch bfs


### PR DESCRIPTION
This is my proposal for #32. It enables users of Haxl to use caches of bounded size, but keeps "cache everything" as the default behaviour.

Please let me know if you have any remarks or want me to change anything.