### PR TITLE
Lax upper bounds

### DIFF
--- a/haxl.cabal
+++ b/haxl.cabal
@@ -38,8 +38,8 @@ extra-source-files:
 library
 
   build-depends:
-    HUnit == 1.2.*,
-    aeson >= 0.6 && < 0.9,
+    HUnit >= 1.2 && < 1.4,
+    aeson >= 0.6 && < 0.11,
     base == 4.*,
     bytestring >= 0.9 && < 0.11,
     containers == 0.5.*,
@@ -51,7 +51,7 @@ library
     text >= 1.1.0.1 && < 1.3,
     time >= 1.4 && < 1.6,
     unordered-containers == 0.2.*,
-    vector == 0.10.*
+    vector >= 0.10 && <0.12
 
   exposed-modules:
     Haxl.Core,


### PR DESCRIPTION
- There are no use of fusion framework of `vector`, so bump is safe
- `aeson` is used for couple of `ToJSON` instances, so this is safe bump as well (might use CPP to use [`toEncoding`](http://hackage.haskell.org/package/aeson-0.10.0.0/docs/Data-Aeson.html#v:toEncoding) with `aeson-0.10`, I can do that if needed)
- `HUnit`  used in tests, they compile and pass.