### PR TITLE
Version bounds on binary package

### DIFF
--- a/haxl.cabal
+++ b/haxl.cabal
@@ -45,7 +45,7 @@ library
     HUnit >= 1.2 && < 1.4,
     aeson >= 0.6 && < 0.12,
     base == 4.*,
-    binary,
+    binary >= 0.7 && < 0.9,
     bytestring >= 0.9 && < 0.11,
     containers == 0.5.*,
     deepseq,


### PR DESCRIPTION
Putting version bounds on binary package in haxl.cabal