### PR TITLE
Allow aeson-1.1

### DIFF
--- a/haxl.cabal
+++ b/haxl.cabal
@@ -43,7 +43,7 @@ library
 
   build-depends:
     HUnit >= 1.2 && < 1.6,
-    aeson >= 0.6 && < 1.1,
+    aeson >= 0.6 && < 1.2,
     base == 4.*,
     binary >= 0.7 && < 0.9,
     bytestring >= 0.9 && < 0.11,


### PR DESCRIPTION
Alternatively we could change dependency to `aeson-compat`, which has less major version bumps (because it has smaller public API surface, yet one have to be careful .e.g. not to rely on instance implementations).