### PR TITLE
Bump more bounds

### DIFF
--- a/haxl.cabal
+++ b/haxl.cabal
@@ -42,10 +42,10 @@ extra-source-files:
 library
 
   build-depends:
-    HUnit >= 1.2 && < 1.6,
+    HUnit >= 1.2 && < 1.7,
     aeson >= 0.6 && < 1.2,
     base == 4.*,
-    binary >= 0.7 && < 0.9,
+    binary >= 0.7 && < 0.10,
     bytestring >= 0.9 && < 0.11,
     containers == 0.5.*,
     deepseq,
@@ -55,7 +55,7 @@ library
     hashable == 1.2.*,
     pretty == 1.1.*,
     text >= 1.1.0.1 && < 1.3,
-    time >= 1.4 && < 1.8,
+    time >= 1.4 && < 1.9,
     transformers,
     unordered-containers == 0.2.*,
     vector >= 0.10 && <0.13


### PR DESCRIPTION
- `binary-0.9` is accidental major jump and is now deprecated, I'm not sure what's best to do, cabal solver should pick `-0.8.x.y.` version
- `HUnit` and `time` changes do not affect use in haxl.