### PR TITLE
Fix docs for memoize1 where an example on Hackage was getting flattened

### DIFF
--- a/Haxl/Core/Memo.hs
+++ b/Haxl/Core/Memo.hs
@@ -127,10 +127,10 @@ memoize a = newMemoWith a >>= runMemo
 --
 -- e.g.:
 --
--- allFriends :: [Int] -> GenHaxl u [Int]
--- allFriends ids = do
---   memoizedFriendsOf <- memoize1 friendsOf
---   concat <$> mapM memoizeFriendsOf ids
+-- > allFriends :: [Int] -> GenHaxl u [Int]
+-- > allFriends ids = do
+-- >   memoizedFriendsOf <- memoize1 friendsOf
+-- >   concat <$> mapM memoizeFriendsOf ids
 --
 -- The above implementation will not invoke the underlying @friendsOf@
 -- repeatedly for duplicate values in @ids@.


### PR DESCRIPTION
The docs in question can be viewed e.g. here:

> https://hackage.haskell.org/package/haxl-0.5.1.0/docs/Haxl-Core.html#v:memoize1

I *believe* the bird syntax is enough to make Hackage format this thing properly but I do not have very much experience with Hackage so I may well be wrong.