### PR TITLE
Update dependencies.

### DIFF
--- a/example/facebook/haxl-facebook.cabal
+++ b/example/facebook/haxl-facebook.cabal
@@ -15,20 +15,20 @@ cabal-version:       >=1.10
 
 library
   build-depends:
-    base >=4.6 && <4.8,
-    aeson >=0.6 && <0.8,
-    fb >=1.0 && <1.1,
-    http-conduit >=2.1 && <2.2,
+    base == 4.*,
+    aeson >=0.6 && <1.3,
+    fb >=1.0,
+    http-conduit >=2.1 && <2.3,
     resourcet >=1.1 && <1.2,
-    text >=0.11 && <1.2,
-    transformers >=0.3 && <0.5,
+    text >=0.11 && < 1.3,
+    transformers,
     hashable >=1.2 && <1.3,
-    data-default >=0.5 && <0.6,
-    http-client-tls >=0.2 && <0.3,
-    time >=1.4 && <1.5,
-    conduit >=1.1 && <1.2,
+    data-default >=0.5 && <0.8,
+    http-client-tls >=0.2 && <0.4,
+    time >= 1.4 && < 1.9,
+    conduit >=1.1 && <1.3,
     async >=2.0 && <2.1,
-    haxl == 0.1.*
+    haxl == 0.5.*
 
   other-extensions:
     OverloadedStrings,


### PR DESCRIPTION
When I was trying to build haxl-facebook, I have found out that it has outdated dependencies.

`
Package has never been configured. Configuring with default flags. If this
fails, please run configure manually.
Resolving dependencies...
Configuring haxl-facebook-0.1.0.0...
Building haxl-facebook-0.1.0.0...
Preprocessing library haxl-facebook-0.1.0.0...
[1 of 2] Compiling FB.DataSource    ( FB/DataSource.hs, dist/build/FB/DataSource.o )

FB/DataSource.hs:39:10:
    Not in scope: type constructor or class ‘Show1’
    Perhaps you meant one of these:
      ‘Show’ (imported from Prelude), ‘ShowS’ (imported from Prelude),
      ‘ShowP’ (imported from Haxl.Core)
`