### PR TITLE
Add semigroup derivation to work with GHC HEAD

### DIFF
--- a/Haxl/Core/Fetch.hs
+++ b/Haxl/Core/Fetch.hs
@@ -37,7 +37,6 @@ import Data.Hashable
 import Data.IORef
 import Data.Int
 import Data.List
-import Data.Monoid
 import Data.Typeable
 import Data.Text (Text)
 import qualified Data.Text as Text

--- a/Haxl/Core/Profile.hs
+++ b/Haxl/Core/Profile.hs
@@ -23,7 +23,6 @@ module Haxl.Core.Profile
 
 import Data.IORef
 import Data.Hashable
-import Data.Monoid
 import Data.Text (Text)
 import Data.Typeable
 import qualified Data.HashMap.Strict as HashMap

--- a/Haxl/Core/Stats.hs
+++ b/Haxl/Core/Stats.hs
@@ -79,7 +79,7 @@ getTimestamp = do
 
 -- | Stats that we collect along the way.
 newtype Stats = Stats [FetchStats]
-  deriving (Show, ToJSON, Monoid)
+  deriving (Show, ToJSON, Monoid, Semigroup)
 
 -- | Pretty-print Stats.
 ppStats :: Stats -> String

--- a/Haxl/Core/Stats.hs
+++ b/Haxl/Core/Stats.hs
@@ -51,6 +51,9 @@ import Data.List (intercalate, maximumBy, minimumBy)
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
 #endif
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup
+#endif
 import Data.Ord (comparing)
 import Data.Text (Text)
 import Data.Time.Clock.POSIX

--- a/Haxl/Core/Stats.hs
+++ b/Haxl/Core/Stats.hs
@@ -48,12 +48,8 @@ import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
 import Data.Int
 import Data.List (intercalate, maximumBy, minimumBy)
-#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
-#endif
-#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
-#endif
 import Data.Ord (comparing)
 import Data.Text (Text)
 import Data.Time.Clock.POSIX

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -61,6 +61,10 @@ library
     unordered-containers == 0.2.*,
     vector >= 0.10 && <0.13
 
+  -- Pre-8.0 dependency on semigroup
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups == 0.18.*
+
   exposed-modules:
     Haxl.Core,
     Haxl.Core.DataCache,


### PR DESCRIPTION
Tiny fix for compilation error with newer versions of GHC, resulting from the addition of the `Semigroup` constraint for `Monoid`.