### PR TITLE
Remove aeson bound from test-suite

### DIFF
--- a/haxl.cabal
+++ b/haxl.cabal
@@ -102,7 +102,7 @@ library
 test-suite test
 
   build-depends:
-    aeson >= 0.6 && < 1.3,
+    aeson,
     HUnit >= 1.2 && < 1.7,
     base == 4.*,
     binary,


### PR DESCRIPTION
It's inherited from the library anyway.