### PR TITLE
Expose MemoVar type

### DIFF
--- a/Haxl/Core/Memo.hs
+++ b/Haxl/Core/Memo.hs
@@ -33,6 +33,7 @@ module Haxl.Core.Memo
   , memoUnique
 
     -- * Local memoization
+  , MemoVar
   , newMemo
   , newMemoWith
   , prepareMemo


### PR DESCRIPTION
Unfortunately we can't refer to `MemoVar` in type signatures otherwise. 
