### PR TITLE
Add correctness tests for outgone-fetches logging

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -91,6 +91,7 @@ module Haxl.Core (
     -- ** Utilities
   , except
   , setError
+  , getMapFromRCMap
 
     -- * Exceptions
   , module Haxl.Core.Exception
@@ -106,5 +107,6 @@ import Haxl.Core.Profile
 import Haxl.Core.Run
 import Haxl.Core.Stats
 import Haxl.Core.Exception
+import Haxl.Core.RequestStore (getMapFromRCMap)
 import Haxl.Core.ShowP (ShowP(..))
 import Haxl.Core.StateStore

--- a/Haxl/Core/DataSource.hs
+++ b/Haxl/Core/DataSource.hs
@@ -386,5 +386,5 @@ submitFetch
   -> (forall a. service -> request a -> IO (IO (Either SomeException a)))
   -> BlockedFetch request
   -> IO (IO ())
-submitFetch service fetch (BlockedFetch request result)
-  = (putResult result =<<) <$> fetch service request
+submitFetch service fetchFn (BlockedFetch request result)
+  = (putResult result =<<) <$> fetchFn service request

--- a/Haxl/Core/Flags.hs
+++ b/Haxl/Core/Flags.hs
@@ -33,7 +33,7 @@ data Flags = Flags
   , report :: {-# UNPACK #-} !Int
     -- ^ Report level:
     --    * 0 = quiet
-    --    * 1 = quiet (legacy, this used to do something)
+    --    * 1 = outgone fetches, for debugging eg: timeouts
     --    * 2 = data fetch stats & errors
     --    * 3 = (same as 2, this used to enable errors)
     --    * 4 = profiling

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Changes in version 2.1.1.0
+
+  * Adds feature to track outgone datasource fetches. This is only turned on
+    for report level greater than 1. The fetches are stored as a running Map
+    in the env ('submittedReqsRef').
+
 # Changes in version 2.1.0.0
 
   * Add a new 'w' parameter to 'GenHaxl' to allow arbitrary writes during

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -132,6 +132,7 @@ test-suite test
   if impl(ghc >= 8.0)
     other-modules:
       AdoTests
+      OutgoneFetchesTests
 
   other-modules:
     AllTests

--- a/tests/AllTests.hs
+++ b/tests/AllTests.hs
@@ -13,6 +13,7 @@ import CoreTests
 import DataCacheTest
 #if __GLASGOW_HASKELL__ >= 801
 import AdoTests
+import OutgoneFetchesTests
 #endif
 #if __GLASGOW_HASKELL__ >= 710
 import ProfileTests
@@ -33,6 +34,7 @@ allTests = TestList
   , TestLabel "DataCacheTests" DataCacheTest.tests
 #if __GLASGOW_HASKELL__ >= 801
   , TestLabel "AdoTests" $ AdoTests.tests False
+  , TestLabel "OutgoneFetchesTest" OutgoneFetchesTests.tests
 #endif
 #if __GLASGOW_HASKELL__ >= 710
   , TestLabel "ProfileTests" ProfileTests.tests

--- a/tests/OutgoneFetchesTests.hs
+++ b/tests/OutgoneFetchesTests.hs
@@ -1,0 +1,137 @@
+-- Copyright (c) 2014-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is distributed under the terms of a BSD license,
+-- found in the LICENSE file.
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ApplicativeDo #-}
+module OutgoneFetchesTests (tests) where
+
+import Haxl.Prelude as Haxl
+import Prelude()
+
+import Haxl.Core
+import Haxl.DataSource.ConcurrentIO
+import Haxl.Core.RequestStore (getMapFromRCMap)
+
+import Data.IORef
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Proxy (Proxy(..))
+import Data.Typeable
+import Test.HUnit
+import System.Timeout
+
+import ExampleDataSource
+import SleepDataSource
+
+testEnv = do
+  exstate <- ExampleDataSource.initGlobalState
+  sleepState <- mkConcurrentIOState
+  let st = stateSet exstate $ stateSet sleepState stateEmpty
+  e <- initEnv st ()
+  return e { flags = (flags e) {report = 1} }
+    -- report=1 to enable fetches tracking
+
+-- A cheap haxl computation we interleave b/w the @sleep@ fetches.
+wombats :: GenHaxl () () Int
+wombats = length <$> listWombats 3
+
+getFetches :: Env () () -> IO (Map Text (Map TypeRep Int))
+getFetches env = getMapFromRCMap <$> readIORef (submittedReqsRef env)
+
+outgoneFetchesTest :: Test
+outgoneFetchesTest = TestCase $ do
+  let
+    withTimeout env h = timeout 2000 $ runHaxl env h -- 2 ms
+
+  -- test that a completed datasource fetch doesn't show up in Env
+  env <- testEnv
+
+  withTimeout env $ do
+    _ <- sleep 1 -- 1 ms
+    _ <- sleep 1 -- should be cached
+    _ <- sleep 1
+    wombats
+
+  fetchesMap <- getFetches env
+  assertEqual "outgoneFetches1" 0 (Map.size fetchesMap)
+
+  -- test that unfinished datasource fetches shows up in Env
+  env <- testEnv
+
+  withTimeout env $ do
+    _ <- sleep 4 -- 4 ms
+    _ <- wombats
+    _ <- sleep 5 -- 4 ms
+    _  <- wombats
+    return ()
+
+  fetchesMap <- getFetches env
+  assertEqual "outgoneFetches2" 1 (Map.size fetchesMap)
+  assertEqual "outgoneFetches2"
+    (Map.fromList
+      [ ( dataSourceName (Proxy :: Proxy (ConcurrentIOReq Sleep))
+        , Map.fromList [(typeOf1 (undefined :: ConcurrentIOReq Sleep a), 2)]
+        )
+      ])
+    fetchesMap
+
+  -- test for finished/unfinished fetches from the same datasource
+  env <- testEnv
+
+  withTimeout env $ do
+    _ <- sleep 1 -- 1 ms
+    _ <- sleep 4
+    _ <- sleep 5
+    return ()
+
+  fetchesMap <- getFetches env
+  assertEqual "outgoneFetches3"
+    (Map.fromList
+      [ ( dataSourceName (Proxy :: Proxy (ConcurrentIOReq Sleep))
+        , Map.fromList [(typeOf1 (undefined :: ConcurrentIOReq Sleep a), 2)]
+        )
+      ])
+    fetchesMap
+
+  -- test for cached requests not showing up twice in ReqCountMap
+  env <- testEnv
+
+  withTimeout env $ do
+    _ <- sleep 4 -- 3 ms
+    _ <- sleep 4
+    return ()
+
+  fetchesMap <- getFetches env
+  assertEqual "outgoneFetches4"
+    (Map.fromList
+      [ ( dataSourceName (Proxy :: Proxy (ConcurrentIOReq Sleep))
+        , Map.fromList [(typeOf1 (undefined :: ConcurrentIOReq Sleep a), 1)]
+        )
+      ])
+    fetchesMap
+
+  -- test for unsent requests not showing up in ReqCountMap
+  env <- testEnv
+
+  withTimeout env $ do
+    _ <- sleep =<< sleep 4 -- second req should never be sent
+    return ()
+
+  fetchesMap <- getFetches env
+  assertEqual "outgoneFetches5"
+    (Map.fromList
+      [ ( dataSourceName (Proxy :: Proxy (ConcurrentIOReq Sleep))
+        , Map.fromList [(typeOf1 (undefined :: ConcurrentIOReq Sleep a), 1)]
+        )
+      ])
+    fetchesMap
+
+
+
+
+tests = TestList
+  [ TestLabel "outgoneFetchesTest" outgoneFetchesTest
+  ]

--- a/tests/SleepDataSource.hs
+++ b/tests/SleepDataSource.hs
@@ -14,7 +14,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 
 module SleepDataSource (
-    sleep,
+    Sleep, sleep,
   ) where
 
 import Haxl.Prelude


### PR DESCRIPTION
Summary:
This adds unit tests to haxl, to make sure we are tracking the outgone
fetches correctly..

Reviewed By: simonmar

Differential Revision: D14683672
