### PR TITLE
Move trace_ function to Util module

### DIFF
--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -115,6 +115,7 @@ import Haxl.Core.StateStore
 import Haxl.Core.Exception
 import Haxl.Core.RequestStore as RequestStore
 import Haxl.Core.DataCache as DataCache
+import Haxl.Core.Util (trace_)
 
 import Control.Arrow (left)
 import Control.Concurrent.STM
@@ -146,11 +147,6 @@ import Data.Typeable
 import GHC.Stack
 import Haxl.Core.CallGraph
 #endif
-
-
-trace_ :: String -> a -> a
-trace_ _ = id
---trace_ = Debug.Trace.trace
 
 -- -----------------------------------------------------------------------------
 -- The environment

--- a/Haxl/Core/Util.hs
+++ b/Haxl/Core/Util.hs
@@ -6,13 +6,15 @@
 
 -- | Internal utilities only.
 --
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 module Haxl.Core.Util
   ( compose
   , textShow
+  , trace_
   ) where
 
 import Data.Text (Text)
-
+import Debug.Trace (trace)
 import qualified Data.Text as Text
 
 -- | Composes a list of endofunctions.
@@ -21,3 +23,9 @@ compose = foldr (.) id
 
 textShow :: (Show a) => a -> Text
 textShow = Text.pack . show
+
+-- | This function can be used to trace a bunch of lines to stdout when
+-- debugging haxl core.
+trace_ :: String -> a -> a
+trace_ _ = id
+--trace_ = Debug.Trace.trace


### PR DESCRIPTION
Summary:
I want to use the trace_ functionality in rest of Haxl code as well.
Instead of defining it in each module, let's move this to Haxl.Core.Util. It's
better also because this module is not exported from haxl.

Differential Revision: D16523067

