### PR TITLE
Make ParallelTests work with MonadFailProposal

### DIFF
--- a/tests/ParallelTests.hs
+++ b/tests/ParallelTests.hs
@@ -21,11 +21,11 @@ sync_test = do
   -- This computation tests that the two arguments of the pOr can fire
   -- without causing an error. The reason we test for this is that the
   -- synchronization involved in this case is a little fragile.
-  runHaxl env $ do
-    False <- (fmap (const False) (sleep 100)
-               `pOr` fmap (const False) (sleep 100))
-             `pOr` fmap (const False) (sleep 200)
-    return ()
+  False <- runHaxl env $ do
+    (fmap (const False) (sleep 100)
+      `pOr` fmap (const False) (sleep 100))
+      `pOr` fmap (const False) (sleep 200)
+  return ()
 
 timing_test = do
   env <- testEnv


### PR DESCRIPTION
Summary: `GenHaxl` doesn't implement the MonadFail class. This causes the ParallelTests to fail on ghc 8.6 and above.

Differential Revision: D18749419

