### PR TITLE
add backgroundFetchAcquireRelease

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -87,6 +87,7 @@ module Haxl.Core (
 
     -- ** Default fetch implementations
   , asyncFetch, asyncFetchWithDispatch, asyncFetchAcquireRelease
+  , backgroundFetchAcquireRelease
   , stubFetch
   , syncFetch
 


### PR DESCRIPTION
Summary: Add a simple mechanism (similar to asyncFetchAcquireRelease) to allow simple converting of data sources from AsyncFetch to BackgroundFetch

Reviewed By: simonmar

Differential Revision: D19272624

