### PR TITLE
Remove FutureFetch from Haxl

### DIFF
--- a/Haxl/Core/DataSource.hs
+++ b/Haxl/Core/DataSource.hs
@@ -143,20 +143,6 @@ data PerformFetch req
     -- ^ Fetches the data in the background, calling 'putResult' at
     -- any time in the future.  This is the best kind of fetch,
     -- because it provides the most concurrency.
-  | FutureFetch ([BlockedFetch req] -> IO (IO ()))
-    -- ^ Returns an IO action that, when performed, waits for the data
-    -- to be received.  This is the second-best type of fetch, because
-    -- the scheduler still has to perform the blocking wait at some
-    -- point in the future, and when it has multiple blocking waits to
-    -- perform, it can't know which one will return first.
-    --
-    -- Why not just forkIO the IO action to make a FutureFetch into a
-    -- BackgroundFetch?  The blocking wait will probably do a safe FFI
-    -- call, which means it needs its own OS thread.  If we don't want
-    -- to create an arbitrary number of OS threads, then FutureFetch
-    -- enables all the blocking waits to be done on a single thread.
-    -- Also, you might have a data source that requires all calls to
-    -- be made in the same OS thread.
 
 
 -- | A 'BlockedFetch' is a pair of

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -195,11 +195,6 @@ data Env u w = Env
        -- become non-empty is how the scheduler blocks waiting for
        -- data fetches to return.
 
-  , pendingWaits :: [IO ()]
-       -- ^ this is a list of IO actions returned by 'FutureFetch'
-       -- data sources.  These do a blocking wait for the results of
-       -- some data fetch.
-
   , speculative :: {-# UNPACK #-} !Int
 
   , writeLogsRef :: {-# UNPACK #-} !(IORef (WriteTree w))
@@ -251,7 +246,6 @@ initEnvWithData states e (dcache, mcache) = do
     , runQueueRef = rq
     , submittedReqsRef = sr
     , completions = comps
-    , pendingWaits = []
     , speculative = 0
     , writeLogsRef = wl
     , writeLogsRefNoMemo = wlnm

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
+# Changes in version 2.3.0.0
+  * Removed `FutureFetch`
+
 # Changes in version 2.2.0.0
 
   * Use BasicHashTable for the Haxl DataCache instead of HashMap
   * API Changes in: Haxl.Core.DataCache, Haxl.Core.Fetch
+  * Removed support for GHC < 8.2
 
 # Changes in version 2.1.2.0
 

--- a/example/facebook/readme.md
+++ b/example/facebook/readme.md
@@ -161,11 +161,10 @@ data PerformFetch
   = SyncFetch  ([BlockedFetch req] -> IO ())
   | AsyncFetch ([BlockedFetch req] -> IO () -> IO ())
   | BackgroundFetch ([BlockedFetch req] -> IO ())
-  | FutureFetch ([BlockedFetch req] -> IO (IO ()))
 ```
 
 A data source can fetch either synchronously (`SyncFetch`),
-asynchronously (`AsyncFetch` or `FutureFetch`), or in the background
+asynchronously (`AsyncFetch`), or in the background
 (`BackgroundFetch`).  The `BackgroundFetch` option is the most
 flexible because it allows fetching to proceed concurrently with
 computation.

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -1,5 +1,5 @@
 name:                haxl
-version:             2.2.0.0
+version:             2.3.0.0
 synopsis:            A Haskell library for efficient, concurrent,
                      and concise data access.
 homepage:            https://github.com/facebook/Haxl


### PR DESCRIPTION
Summary: FutureFetch is unused (except for one test) and overall has not proven itself to be a useful fetch type. It adds a new waiting point (the others being BackgroundFetch and Async/Sync fetches) which can add latency. For example if all three are dispatched in one round how would the scheduler know ahead of time which one to wait on in order to make forward progress.

Reviewed By: simonmar

Differential Revision: D19410093

