### PR TITLE
Add tracking of Fetch Stats for the same batch

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -50,6 +50,7 @@ module Haxl.Core (
   , numFetches
   , ppStats
   , ppFetchStats
+  , aggregateFetchBatches
   , Profile
   , emptyProfile
   , profile

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Changes in version <next>
+  * Added fetchBatchId to FetchStats
+
 # Changes in version 2.3.0.0
   * Removed `FutureFetch`
 

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -137,6 +137,7 @@ test-suite test
     ParallelTests
     ProfileTests
     SleepDataSource
+    StatsTests
     TestBadDataSource
     TestExampleDataSource
     TestTypes

--- a/tests/AllTests.hs
+++ b/tests/AllTests.hs
@@ -19,6 +19,7 @@ import TestBadDataSource
 import FullyAsyncTest
 import WriteTests
 import ParallelTests
+import StatsTests
 
 import Test.HUnit
 
@@ -37,4 +38,5 @@ allTests = TestList
   , TestLabel "FullyAsyncTest" FullyAsyncTest.tests
   , TestLabel "WriteTest" WriteTests.tests
   , TestLabel "ParallelTest" ParallelTests.tests
+  , TestLabel "StatsTests" StatsTests.tests
   ]

--- a/tests/StatsTests.hs
+++ b/tests/StatsTests.hs
@@ -1,0 +1,53 @@
+-- Copyright (c) 2014-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is distributed under the terms of a BSD license,
+-- found in the LICENSE file.
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module StatsTests (tests) where
+
+import Test.HUnit
+import Data.List
+
+import Haxl.Core
+
+aggregateBatches :: Test
+aggregateBatches = TestCase $ do
+  let
+    statsNoBatches = [ FetchStats { fetchDataSource = "foo"
+                                  , fetchBatchSize = 7
+                                  , fetchStart = 0
+                                  , fetchDuration = 10
+                                  , fetchSpace = 1
+                                  , fetchFailures = 2
+                                  , fetchBatchId = n }
+                                  | n <- reverse [1..10] ++ [11..20] ]
+                     ++ [ FetchCall "A" ["B"], FetchCall "C" ["D"] ]
+    fetchBatch = [ FetchStats { fetchDataSource = "batch"
+                              , fetchBatchSize = 1
+                              , fetchStart = 100
+                              , fetchDuration = 1000 * n
+                              , fetchSpace = 3
+                              , fetchFailures = if n <= 3 then 1 else 0
+                              , fetchBatchId = 123 } | n <- [1..50] ]
+    agg (sz,bids) FetchStats{..} = (sz + fetchBatchSize, fetchBatchId:bids)
+    agg _ _ = error "unexpected"
+    agg' = foldl' agg (0,[])
+    aggNoBatch = aggregateFetchBatches agg' (Stats statsNoBatches)
+    expectedNoBatch = [(7, [n]) | n <- reverse [1..20] :: [Int]]
+    aggBatch = aggregateFetchBatches agg' (Stats fetchBatch)
+    expectedResultBatch = (50, [123 | _ <- [1..50] :: [Int]])
+    aggInterspersedBatch =
+      aggregateFetchBatches agg'
+      (Stats $ intersperse (head fetchBatch) statsNoBatches)
+    expectedResultInterspersed =
+      (21, [123 | _ <- [1..21] :: [Int]]) : expectedNoBatch
+  assertEqual "No batch has no change" expectedNoBatch aggNoBatch
+  assertEqual "Batch is combined" [expectedResultBatch] aggBatch
+  assertEqual
+    "Grouping works as expected" expectedResultInterspersed aggInterspersedBatch
+
+tests = TestList [TestLabel "Aggregate Batches" aggregateBatches]


### PR DESCRIPTION
Summary:
Right now BackgroundFetches produce multiple FetchStats for the same batch, but it is not possible to link these together to get an idea of how big the batch was.
This introduces a field to FetchStats that can be used to link batches together as well as a utility method to do this in a default manner

Reviewed By: watashi

Differential Revision: D19469048

