### PR TITLE
Fix allocation counting when batching from child threads

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -88,7 +88,7 @@ module Haxl.Core (
 
     -- ** Default fetch implementations
   , asyncFetch, asyncFetchWithDispatch, asyncFetchAcquireRelease
-  , backgroundFetchAcquireRelease
+  , backgroundFetchAcquireRelease, backgroundFetchAcquireReleaseMVar
   , stubFetch
   , syncFetch
 

--- a/tests/WorkDataSource.hs
+++ b/tests/WorkDataSource.hs
@@ -10,8 +10,10 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module WorkDataSource (
+    mkWorkState,
     work,
   ) where
 
@@ -19,26 +21,65 @@ import Haxl.Prelude
 import Prelude ()
 
 import Haxl.Core
-import Haxl.DataSource.ConcurrentIO
 
 import Control.Exception
 import Data.Hashable
 import Data.Typeable
+import Control.Monad (void)
+import Control.Concurrent.MVar
+
+
+data Work a where
+  Work :: Integer -> Work Integer
+  deriving Typeable
+
+deriving instance Eq (Work a)
+deriving instance Show (Work a)
+instance ShowP Work where showp = show
+
+instance Hashable (Work a) where
+   hashWithSalt s (Work a) = hashWithSalt s (0::Int,a)
+
+instance DataSourceName Work where
+  dataSourceName _ = "Work"
+
+instance StateKey Work where
+  data State Work = WorkState
+
+newtype Service = Service (MVar [IO ()])
+
+run :: Work a -> IO a
+run (Work n) = evaluate (sum [1..n]) >> return n
+
+mkService :: IO Service
+mkService = Service <$> newMVar []
+
+process :: Service -> IO ()
+process (Service q) = do
+  r <- swapMVar q []
+  sequence_ r
+
+enqueue :: Service -> Work a -> IO (IO (Either SomeException a))
+enqueue (Service q) w = do
+  res <- newEmptyMVar
+  let r = do
+        v <- Control.Exception.try $ run w
+        putMVar res v
+  modifyMVar_ q (return . (:) r)
+  return (takeMVar res)
+
+instance DataSource u Work where
+  fetch = backgroundFetchAcquireReleaseMVar
+    mkService
+    (\_ -> return ())
+    -- pretend we are ready so that process does the work
+    (\_ _ m -> void $ tryPutMVar m ())
+    process
+    enqueue
+
+
+mkWorkState :: State Work
+mkWorkState = WorkState
 
 work :: Integer -> GenHaxl u w Integer
 work n = dataFetch (Work n)
-
-data Work deriving Typeable
-instance ConcurrentIO Work where
-  data ConcurrentIOReq Work a where
-    Work :: Integer -> ConcurrentIOReq Work Integer
-
-  performIO (Work n) = evaluate (sum [1..n]) >> return n
-
-deriving instance Eq (ConcurrentIOReq Work a)
-deriving instance Show (ConcurrentIOReq Work a)
-
-instance ShowP (ConcurrentIOReq Work) where showp = show
-
-instance Hashable (ConcurrentIOReq Work a) where
-  hashWithSalt s (Work n) = hashWithSalt s n


### PR DESCRIPTION
Summary: When processing batches it would be quite easy to double count the allocations from child threads. This diff fixes it by setting the counter to zero after taking the current allocation count

Reviewed By: malmerey

Differential Revision: D19580472

