### PR TITLE
add a backgroundFetchAcquireReleaseMVar API for building background datasources from Haskell threads

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -88,7 +88,7 @@ module Haxl.Core (
 
     -- ** Default fetch implementations
   , asyncFetch, asyncFetchWithDispatch, asyncFetchAcquireRelease
-  , backgroundFetchAcquireRelease
+  , backgroundFetchAcquireRelease, backgroundFetchAcquireReleaseMVar
   , stubFetch
   , syncFetch
 


### PR DESCRIPTION
Summary: Add a new API that makes it convenient to call backgroundFetchAcquireRelease from Haskell without going through the C APIs

Reviewed By: simonmar

Differential Revision: D19580473

