### PR TITLE
add backgroundFetchSeq and backgroundFetchPar

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -88,6 +88,7 @@ module Haxl.Core (
 
     -- ** Default fetch implementations
   , asyncFetch, asyncFetchWithDispatch, asyncFetchAcquireRelease
+  , backgroundFetchSeq, backgroundFetchPar
   , backgroundFetchAcquireRelease, backgroundFetchAcquireReleaseMVar
   , stubFetch
   , syncFetch

--- a/tests/TestBadDataSource.hs
+++ b/tests/TestBadDataSource.hs
@@ -123,4 +123,6 @@ tests = TestList
   [ TestLabel "badDataSourceTest async" (go Async)
   , TestLabel "badDataSourceTest background" (go Background)
   , TestLabel "badDataSourceTest backgroundMVar" (go BackgroundMVar)
+  , TestLabel "badDataSourceTest backgroundFetchSeq" (go BackgroundSeq)
+  , TestLabel "badDataSourceTest backgroundFetchPar" (go BackgroundPar)
   ]


### PR DESCRIPTION
Summary: Add backgroundFetch methods that run a batch in the background. The Seq method will run the batch sequentially, the par method will run each request in the batch in parallel

Reviewed By: simonmar

Differential Revision: D20029453

