### PR TITLE
profile more accurately

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -51,10 +51,10 @@ module Haxl.Core (
   , ppStats
   , ppFetchStats
   , aggregateFetchBatches
-  , Profile
+  , Profile(..)
   , emptyProfile
-  , profile
   , ProfileLabel
+  , ProfileKey
   , ProfileData(..)
   , emptyProfileData
   , AllocCount

--- a/Haxl/Core/Memo.hs
+++ b/Haxl/Core/Memo.hs
@@ -74,8 +74,9 @@ cachedComputation
 
 cachedComputation req haxl = GenHaxl $ \env@Env{..} -> do
   ifProfiling flags $
-     modifyIORef' profRef (incrementMemoHitCounterFor
-     profLabel)
+    modifyIORef'
+      profRef
+      (incrementMemoHitCounterFor (profCurrentKey profCurrent))
   mbRes <- DataCache.lookup req memoCache
   case mbRes of
     Just ivar -> unHaxl (getIVarWithWrites ivar) env
@@ -101,7 +102,9 @@ preCacheComputation
   => req a -> GenHaxl u w a -> GenHaxl u w a
 preCacheComputation req haxl = GenHaxl $ \env@Env{..} -> do
   ifProfiling flags $
-     modifyIORef' profRef (incrementMemoHitCounterFor profLabel)
+    modifyIORef'
+      profRef
+      (incrementMemoHitCounterFor (profCurrentKey profCurrent))
   mbRes <- DataCache.lookup req memoCache
   case mbRes of
     Just _ -> return $ Throw $ toException $ InvalidParameter

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -83,6 +83,9 @@ module Haxl.Core.Monad
   , speculate
   , imperative
 
+    -- * Profiling
+  , ProfileCurrent(..)
+
     -- * JobList
   , JobList(..)
   , appendJobList
@@ -169,7 +172,7 @@ data Env u w = Env
      -- ^ keeps track of a Unique ID for each batch dispatched with stats
      -- enabled, for aggregating after.
 
-  , profLabel    :: ProfileLabel
+  , profCurrent    :: ProfileCurrent
       -- ^ current profiling label, see 'withLabel'
 
   , profRef      :: {-# UNPACK #-} !(IORef Profile)
@@ -222,6 +225,11 @@ data Env u w = Env
 #endif
   }
 
+data ProfileCurrent = ProfileCurrent
+  { profCurrentKey ::  {-# UNPACK #-} !ProfileKey
+  , profCurrentLabel :: {-# UNPACK #-} !ProfileLabel
+  }
+
 type Caches u w = (DataCache (IVar u w), DataCache (IVar u w))
 
 caches :: Env u w -> Caches u w
@@ -248,7 +256,7 @@ initEnvWithData states e (dcache, mcache) = do
     , states = states
     , statsRef = sref
     , statsBatchIdRef = sbref
-    , profLabel = "MAIN"
+    , profCurrent = ProfileCurrent 0 "MAIN"
     , profRef = pref
     , reqStoreRef = rs
     , runQueueRef = rq

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changes in version <next>
   * Added fetchBatchId to FetchStats
+  * Profiling now tracks full stacks
 
 # Changes in version 2.3.0.0
   * Removed `FutureFetch`

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -164,7 +164,8 @@ executable monadbench
     base,
     haxl,
     hashable,
-    time
+    time,
+    optparse-applicative
   main-is:
     MonadBench.hs
   other-modules:

--- a/tests/MonadBench.hs
+++ b/tests/MonadBench.hs
@@ -5,13 +5,15 @@
 -- found in the LICENSE file.
 
 -- | Benchmarking tool for core performance characteristics of the Haxl monad.
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ApplicativeDo, RecordWildCards #-}
 module MonadBench (main) where
 
 import Control.Monad
 import Data.List as List
+import Data.Maybe
 import Data.Time.Clock
-import System.Environment
+import Options.Applicative
 import System.Exit
 import System.IO
 import Text.Printf
@@ -22,114 +24,136 @@ import Prelude()
 import Haxl.Core.Memo (newMemoWith, runMemo)
 
 import Haxl.Core
+import Haxl.Core.Util
 
 import ExampleDataSource
 
 newtype SimpleWrite = SimpleWrite Text deriving (Eq, Show)
 
-testEnv :: IO (Env () SimpleWrite)
-testEnv = do
+testEnv :: Int -> IO (Env () SimpleWrite)
+testEnv report = do
   exstate <- ExampleDataSource.initGlobalState
   let st = stateSet exstate stateEmpty
-  initEnv st ()
+  env <- initEnv st ()
+  return env { flags = (flags env) { report = report } }
 
-main :: IO ()
-main = do
-  [test,n_] <- getArgs
-  let n = read n_
-  env <- testEnv
-  t0 <- getCurrentTime
-  case test of
+type Test = (String, Int, Int -> GenHaxl () SimpleWrite ())
+
+testName :: Test -> String
+testName (t,_,_) = t
+
+allTests :: [Test]
+allTests =
     -- parallel, identical queries
-    "par1" -> runHaxl env $
-       Haxl.sequence_ (replicate n (listWombats 3))
+  [ ("par1", large, \n -> Haxl.sequence_ (replicate n (listWombats 3)))
     -- parallel, distinct queries
-    "par2" -> runHaxl env $
-       Haxl.sequence_ (map listWombats [1..fromIntegral n])
+  , ("par2", medium, \n ->
+        Haxl.sequence_ (map listWombats [1..fromIntegral n]))
     -- sequential, identical queries
-    "seqr" -> runHaxl env $
-       foldr andThen (return ()) (replicate n (listWombats 3))
+  , ("seqr", huge, \n ->
+        foldr andThen (return ()) (replicate n (listWombats 3)))
     -- sequential, left-associated, distinct queries
-    "seql" -> runHaxl env $ do
+  , ("seql", medium, \n -> do
        _ <- foldl andThen (return []) (map listWombats [1.. fromIntegral n])
-       return ()
-    "tree" -> runHaxl env $ void $ tree n
+       return ())
     -- No memoization
-    "memo0" -> runHaxl env $
-      Haxl.sequence_ [unionWombats | _ <- [1..n]]
+  , ("memo0", small, \n -> Haxl.sequence_ [unionWombats | _ <- [1..n]])
     -- One put, N gets.
-    "memo1" -> runHaxl env $
-      Haxl.sequence_ [memo (42 :: Int) unionWombats | _ <- [1..n]]
+  , ("memo1", medium_large, \n ->
+        Haxl.sequence_ [memo (42 :: Int) unionWombats | _ <- [1..n]])
     -- N puts, N gets.
-    "memo2" -> runHaxl env $
-      Haxl.sequence_ [memo (i :: Int) unionWombats | i <- [1..n]]
-    "memo3" ->
-      runHaxl env $ do
+  , ("memo2", small, \n ->
+        Haxl.sequence_ [memo (i :: Int) unionWombats | i <- [1..n]])
+  , ("memo3", medium_large, \n -> do
         ref <- newMemoWith unionWombats
         let c = runMemo ref
-        Haxl.sequence_ [c | _ <- [1..n]]
-    "memo4" ->
-      runHaxl env $ do
+        Haxl.sequence_ [c | _ <- [1..n]])
+  , ("memo4", small, \n -> do
         let f = unionWombatsTo
-        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]]
-    "memo5" ->
-      runHaxl env $ do
+        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]])
+  , ("memo5", medium_large, \n -> do
         f <- memoize1 unionWombatsTo
-        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]]
-    "memo6" ->
-      runHaxl env $ do
+        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]])
+  , ("memo6", small, \n -> do
         let f = unionWombatsFromTo
         Haxl.sequence_ [ f x y
                        | x <- take n $ cycle [100, 200 .. 1000]
                        , let y = x + 1000
-                       ]
-    "memo7" ->
-      runHaxl env $ do
+                       ])
+  , ("memo7", medium_large, \n -> do
         f <- memoize2 unionWombatsFromTo
         Haxl.sequence_ [ f x y
                        | x <- take n $ cycle [100, 200 .. 1000]
                        , let y = x + 1000
-                       ]
+                       ])
+  , ("cc1", medium_large, \n ->
+        Haxl.sequence_ [ cachedComputation (ListWombats 1000) unionWombats
+                       | _ <- [1..n]
+                       ])
+  , ("tree", 20, \n -> void $ tree n (\_ act -> act))
+  , ("tree_labels", 20, \n -> void $
+      tree n (\n act -> withLabel (textShow n) act))
     -- parallel writes
-    "write1" -> runHaxl env $
-      Haxl.sequence_ (replicate n (tellWrite (SimpleWrite "haha")))
-
+  , ("write1", large, \n ->
+        Haxl.sequence_ (replicate n (tellWrite (SimpleWrite "haha"))))
     -- sequential writes
-    "write2" -> runHaxl env $
-      foldr andThen (return ()) (replicate n (tellWrite (SimpleWrite "haha")))
+  , ("write2", huge, \n -> foldr
+        andThen
+        (return ())
+        (replicate n (tellWrite (SimpleWrite "haha"))))
+  ]
+  where
+    huge = large * 10
+    large =  medium * 10
+    medium_large =  medium * 4
+    medium = 200000
+    small = 1000
 
+data Options = Options
+  { test :: String
+  , nOverride :: Maybe Int
+  , reportFlag :: Int
+  }
 
-    "cc1" -> runHaxl env $
-      Haxl.sequence_ [ cachedComputation (ListWombats 1000) unionWombats
-                     | _ <- [1..n]
-                     ]
-
-    _ -> do
-      hPutStrLn stderr $ "syntax: monadbench " ++ concat
-        [ "par1"
-        , "par2"
-        , "seqr"
-        , "seql"
-        , "memo0"
-        , "memo1"
-        , "memo2"
-        , "memo3"
-        , "memo4"
-        , "memo5"
-        , "memo6"
-        , "memo7"
-        , "cc1"
-        ]
-      exitWith (ExitFailure 1)
+runTest :: Options -> Test -> IO ()
+runTest Options{..} (t, nDef, act) = do
+  let n = fromMaybe nDef nOverride
+  env <- testEnv reportFlag
+  t0 <- getCurrentTime
+  runHaxl env $ act n
   t1 <- getCurrentTime
-  printf "%10s: %10d reqs: %.2fs\n"
-    test n (realToFrac (t1 `diffUTCTime` t0) :: Double)
+  printf "%12s: %10d reqs: %.2fs\n"
+    t n (realToFrac (t1 `diffUTCTime` t0) :: Double)
 
-tree :: Int -> GenHaxl () SimpleWrite [Id]
-tree 0 = listWombats 0
-tree n = concat <$> Haxl.sequence
-  [ tree (n-1)
-  , listWombats (fromIntegral n), tree (n-1)
+optionsParser :: Parser Options
+optionsParser = do
+  test <- argument str (metavar "TEST")
+  reportFlag <- option auto (long "report" <> value 0 <> metavar "REPORT")
+  nOverride <- optional $ argument auto (metavar "NUM")
+  return Options{..}
+
+main :: IO ()
+main = do
+  opts@Options{..} <- execParser $ info optionsParser mempty
+  let tests = if test == "all"
+        then allTests
+        else filter ((==) test . testName) allTests
+  when
+    (null tests)
+    (do
+        hPutStrLn stderr $ "syntax: monadbench [all|" ++
+          intercalate "|" (map testName allTests) ++ "]"
+        exitWith (ExitFailure 1))
+  Control.Monad.mapM_ (runTest opts) tests
+
+tree
+  :: Int
+  -> (Int -> GenHaxl () SimpleWrite [Id] -> GenHaxl () SimpleWrite [Id])
+  -> GenHaxl () SimpleWrite [Id]
+tree 0 wrap = wrap 0 $ listWombats 0
+tree n wrap = wrap n $ concat <$> Haxl.sequence
+  [ tree (n-1) wrap
+  , listWombats (fromIntegral n), tree (n-1) wrap
   ]
 
 unionWombats :: GenHaxl () SimpleWrite [Id]


### PR DESCRIPTION
Summary:
Currently profiling with labels does not track full stacks.
This is problematic in the case where all top level methods end up calling a common method with a label, as we have no way of attributing to the top level methods.
Eg if A/B/C all call X when running work then we cannot tell which work is expensive, as we have no connection from the work through X

Reviewed By: simonmar

Differential Revision: D20384255

