### PR TITLE
Track fetches/memos accurately in profiling

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -51,10 +51,10 @@ module Haxl.Core (
   , ppStats
   , ppFetchStats
   , aggregateFetchBatches
-  , Profile
+  , Profile(..)
   , emptyProfile
-  , profile
   , ProfileLabel
+  , ProfileKey
   , ProfileData(..)
   , emptyProfileData
   , AllocCount

--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -44,6 +44,7 @@ module Haxl.Core (
     -- ** Statistics
   , Stats(..)
   , FetchStats(..)
+  , CallId
   , Microseconds
   , Timestamp
   , emptyStats
@@ -52,6 +53,8 @@ module Haxl.Core (
   , ppFetchStats
   , aggregateFetchBatches
   , Profile(..)
+  , ProfileMemo(..)
+  , ProfileFetch(..)
   , emptyProfile
   , ProfileLabel
   , ProfileKey
@@ -59,7 +62,6 @@ module Haxl.Core (
   , emptyProfileData
   , AllocCount
   , LabelHitCount
-  , MemoHitCount
 
     -- ** Tracing flags
   , Flags(..)

--- a/Haxl/Core/Memo.hs
+++ b/Haxl/Core/Memo.hs
@@ -74,8 +74,9 @@ cachedComputation
 
 cachedComputation req haxl = GenHaxl $ \env@Env{..} -> do
   ifProfiling flags $
-     modifyIORef' profRef (incrementMemoHitCounterFor
-     profLabel)
+    modifyIORef'
+      profRef
+      (incrementMemoHitCounterFor (profCurrentKey profCurrent))
   mbRes <- DataCache.lookup req memoCache
   case mbRes of
     Just ivar -> unHaxl (getIVarWithWrites ivar) env
@@ -101,7 +102,9 @@ preCacheComputation
   => req a -> GenHaxl u w a -> GenHaxl u w a
 preCacheComputation req haxl = GenHaxl $ \env@Env{..} -> do
   ifProfiling flags $
-     modifyIORef' profRef (incrementMemoHitCounterFor profLabel)
+    modifyIORef'
+      profRef
+      (incrementMemoHitCounterFor (profCurrentKey profCurrent))
   mbRes <- DataCache.lookup req memoCache
   case mbRes of
     Just _ -> return $ Throw $ toException $ InvalidParameter

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -83,6 +83,9 @@ module Haxl.Core.Monad
   , speculate
   , imperative
 
+    -- * Profiling
+  , ProfileCurrent(..)
+
     -- * JobList
   , JobList(..)
   , appendJobList
@@ -169,7 +172,7 @@ data Env u w = Env
      -- ^ keeps track of a Unique ID for each batch dispatched with stats
      -- enabled, for aggregating after.
 
-  , profLabel    :: ProfileLabel
+  , profCurrent    :: ProfileCurrent
       -- ^ current profiling label, see 'withLabel'
 
   , profRef      :: {-# UNPACK #-} !(IORef Profile)
@@ -222,6 +225,11 @@ data Env u w = Env
 #endif
   }
 
+data ProfileCurrent = ProfileCurrent
+  { profCurrentKey ::  {-# UNPACK #-} !ProfileKey
+  , profCurrentLabel :: {-# UNPACK #-} !ProfileLabel
+  }
+
 type Caches u w = (DataCache (IVar u w), DataCache (IVar u w))
 
 caches :: Env u w -> Caches u w
@@ -248,7 +256,7 @@ initEnvWithData states e (dcache, mcache) = do
     , states = states
     , statsRef = sref
     , statsBatchIdRef = sbref
-    , profLabel = "MAIN"
+    , profCurrent = ProfileCurrent 0 "MAIN"
     , profRef = pref
     , reqStoreRef = rs
     , runQueueRef = rq

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changes in version <next>
   * Added fetchBatchId to FetchStats
+  * Profiling now tracks full stacks
 
 # Changes in version 2.3.0.0
   * Removed `FutureFetch`

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changes in version <next>
   * Added fetchBatchId to FetchStats
-  * Profiling now tracks full stacks
+  * Profiling now tracks full stacks and links each label to memos/fetches
 
 # Changes in version 2.3.0.0
   * Removed `FutureFetch`

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -164,7 +164,8 @@ executable monadbench
     base,
     haxl,
     hashable,
-    time
+    time,
+    optparse-applicative
   main-is:
     MonadBench.hs
   other-modules:

--- a/tests/BatchTests.hs
+++ b/tests/BatchTests.hs
@@ -141,6 +141,8 @@ cacheReuse future = do
   tao <- MockTAO.initGlobalState future
   let st = stateSet tao stateEmpty
   env2 <- initEnvWithData st testinput (caches env)
+  cid <- readIORef (callIdRef env2)
+  assertBool "callId is unique" (cid > 0)
 
   -- ensure no more data fetching rounds needed
   expectResultWithEnv 12 batching7_ env2

--- a/tests/MonadBench.hs
+++ b/tests/MonadBench.hs
@@ -5,13 +5,15 @@
 -- found in the LICENSE file.
 
 -- | Benchmarking tool for core performance characteristics of the Haxl monad.
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ApplicativeDo, RecordWildCards #-}
 module MonadBench (main) where
 
 import Control.Monad
 import Data.List as List
+import Data.Maybe
 import Data.Time.Clock
-import System.Environment
+import Options.Applicative
 import System.Exit
 import System.IO
 import Text.Printf
@@ -22,114 +24,136 @@ import Prelude()
 import Haxl.Core.Memo (newMemoWith, runMemo)
 
 import Haxl.Core
+import Haxl.Core.Util
 
 import ExampleDataSource
 
 newtype SimpleWrite = SimpleWrite Text deriving (Eq, Show)
 
-testEnv :: IO (Env () SimpleWrite)
-testEnv = do
+testEnv :: Int -> IO (Env () SimpleWrite)
+testEnv report = do
   exstate <- ExampleDataSource.initGlobalState
   let st = stateSet exstate stateEmpty
-  initEnv st ()
+  env <- initEnv st ()
+  return env { flags = (flags env) { report = report } }
 
-main :: IO ()
-main = do
-  [test,n_] <- getArgs
-  let n = read n_
-  env <- testEnv
-  t0 <- getCurrentTime
-  case test of
+type Test = (String, Int, Int -> GenHaxl () SimpleWrite ())
+
+testName :: Test -> String
+testName (t,_,_) = t
+
+allTests :: [Test]
+allTests =
     -- parallel, identical queries
-    "par1" -> runHaxl env $
-       Haxl.sequence_ (replicate n (listWombats 3))
+  [ ("par1", large, \n -> Haxl.sequence_ (replicate n (listWombats 3)))
     -- parallel, distinct queries
-    "par2" -> runHaxl env $
-       Haxl.sequence_ (map listWombats [1..fromIntegral n])
+  , ("par2", medium, \n ->
+        Haxl.sequence_ (map listWombats [1..fromIntegral n]))
     -- sequential, identical queries
-    "seqr" -> runHaxl env $
-       foldr andThen (return ()) (replicate n (listWombats 3))
+  , ("seqr", huge, \n ->
+        foldr andThen (return ()) (replicate n (listWombats 3)))
     -- sequential, left-associated, distinct queries
-    "seql" -> runHaxl env $ do
+  , ("seql", medium, \n -> do
        _ <- foldl andThen (return []) (map listWombats [1.. fromIntegral n])
-       return ()
-    "tree" -> runHaxl env $ void $ tree n
+       return ())
     -- No memoization
-    "memo0" -> runHaxl env $
-      Haxl.sequence_ [unionWombats | _ <- [1..n]]
+  , ("memo0", small, \n -> Haxl.sequence_ [unionWombats | _ <- [1..n]])
     -- One put, N gets.
-    "memo1" -> runHaxl env $
-      Haxl.sequence_ [memo (42 :: Int) unionWombats | _ <- [1..n]]
+  , ("memo1", medium_large, \n ->
+        Haxl.sequence_ [memo (42 :: Int) unionWombats | _ <- [1..n]])
     -- N puts, N gets.
-    "memo2" -> runHaxl env $
-      Haxl.sequence_ [memo (i :: Int) unionWombats | i <- [1..n]]
-    "memo3" ->
-      runHaxl env $ do
+  , ("memo2", small, \n ->
+        Haxl.sequence_ [memo (i :: Int) unionWombats | i <- [1..n]])
+  , ("memo3", medium_large, \n -> do
         ref <- newMemoWith unionWombats
         let c = runMemo ref
-        Haxl.sequence_ [c | _ <- [1..n]]
-    "memo4" ->
-      runHaxl env $ do
+        Haxl.sequence_ [c | _ <- [1..n]])
+  , ("memo4", small, \n -> do
         let f = unionWombatsTo
-        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]]
-    "memo5" ->
-      runHaxl env $ do
+        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]])
+  , ("memo5", medium_large, \n -> do
         f <- memoize1 unionWombatsTo
-        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]]
-    "memo6" ->
-      runHaxl env $ do
+        Haxl.sequence_ [f x | x <- take n $ cycle [100, 200 .. 1000]])
+  , ("memo6", small, \n -> do
         let f = unionWombatsFromTo
         Haxl.sequence_ [ f x y
                        | x <- take n $ cycle [100, 200 .. 1000]
                        , let y = x + 1000
-                       ]
-    "memo7" ->
-      runHaxl env $ do
+                       ])
+  , ("memo7", medium_large, \n -> do
         f <- memoize2 unionWombatsFromTo
         Haxl.sequence_ [ f x y
                        | x <- take n $ cycle [100, 200 .. 1000]
                        , let y = x + 1000
-                       ]
+                       ])
+  , ("cc1", medium_large, \n ->
+        Haxl.sequence_ [ cachedComputation (ListWombats 1000) unionWombats
+                       | _ <- [1..n]
+                       ])
+  , ("tree", 20, \n -> void $ tree n (\_ act -> act))
+  , ("tree_labels", 20, \n -> void $
+      tree n (\n act -> withLabel (textShow n) act))
     -- parallel writes
-    "write1" -> runHaxl env $
-      Haxl.sequence_ (replicate n (tellWrite (SimpleWrite "haha")))
-
+  , ("write1", large, \n ->
+        Haxl.sequence_ (replicate n (tellWrite (SimpleWrite "haha"))))
     -- sequential writes
-    "write2" -> runHaxl env $
-      foldr andThen (return ()) (replicate n (tellWrite (SimpleWrite "haha")))
+  , ("write2", huge, \n -> foldr
+        andThen
+        (return ())
+        (replicate n (tellWrite (SimpleWrite "haha"))))
+  ]
+  where
+    huge = large * 10
+    large =  medium * 10
+    medium_large =  medium * 4
+    medium = 200000
+    small = 1000
 
+data Options = Options
+  { test :: String
+  , nOverride :: Maybe Int
+  , reportFlag :: Int
+  }
 
-    "cc1" -> runHaxl env $
-      Haxl.sequence_ [ cachedComputation (ListWombats 1000) unionWombats
-                     | _ <- [1..n]
-                     ]
-
-    _ -> do
-      hPutStrLn stderr $ "syntax: monadbench " ++ concat
-        [ "par1"
-        , "par2"
-        , "seqr"
-        , "seql"
-        , "memo0"
-        , "memo1"
-        , "memo2"
-        , "memo3"
-        , "memo4"
-        , "memo5"
-        , "memo6"
-        , "memo7"
-        , "cc1"
-        ]
-      exitWith (ExitFailure 1)
+runTest :: Options -> Test -> IO ()
+runTest Options{..} (t, nDef, act) = do
+  let n = fromMaybe nDef nOverride
+  env <- testEnv reportFlag
+  t0 <- getCurrentTime
+  runHaxl env $ act n
   t1 <- getCurrentTime
-  printf "%10s: %10d reqs: %.2fs\n"
-    test n (realToFrac (t1 `diffUTCTime` t0) :: Double)
+  printf "%12s: %10d reqs: %.2fs\n"
+    t n (realToFrac (t1 `diffUTCTime` t0) :: Double)
 
-tree :: Int -> GenHaxl () SimpleWrite [Id]
-tree 0 = listWombats 0
-tree n = concat <$> Haxl.sequence
-  [ tree (n-1)
-  , listWombats (fromIntegral n), tree (n-1)
+optionsParser :: Parser Options
+optionsParser = do
+  test <- argument str (metavar "TEST")
+  reportFlag <- option auto (long "report" <> value 0 <> metavar "REPORT")
+  nOverride <- optional $ argument auto (metavar "NUM")
+  return Options{..}
+
+main :: IO ()
+main = do
+  opts@Options{..} <- execParser $ info optionsParser mempty
+  let tests = if test == "all"
+        then allTests
+        else filter ((==) test . testName) allTests
+  when
+    (null tests)
+    (do
+        hPutStrLn stderr $ "syntax: monadbench [all|" ++
+          intercalate "|" (map testName allTests) ++ "]"
+        exitWith (ExitFailure 1))
+  Control.Monad.mapM_ (runTest opts) tests
+
+tree
+  :: Int
+  -> (Int -> GenHaxl () SimpleWrite [Id] -> GenHaxl () SimpleWrite [Id])
+  -> GenHaxl () SimpleWrite [Id]
+tree 0 wrap = wrap 0 $ listWombats 0
+tree n wrap = wrap n $ concat <$> Haxl.sequence
+  [ tree (n-1) wrap
+  , listWombats (fromIntegral n), tree (n-1) wrap
   ]
 
 unionWombats :: GenHaxl () SimpleWrite [Id]

--- a/tests/StatsTests.hs
+++ b/tests/StatsTests.hs
@@ -11,8 +11,20 @@ module StatsTests (tests) where
 
 import Test.HUnit
 import Data.List
+import Data.Maybe
 
+import Haxl.Prelude
 import Haxl.Core
+import Prelude()
+
+
+import ExampleDataSource
+import SleepDataSource
+import Haxl.DataSource.ConcurrentIO
+
+import Control.Monad (void)
+import Data.IORef
+import qualified Data.HashMap.Strict as HashMap
 
 aggregateBatches :: Test
 aggregateBatches = TestCase $ do
@@ -23,16 +35,18 @@ aggregateBatches = TestCase $ do
                                   , fetchDuration = 10
                                   , fetchSpace = 1
                                   , fetchFailures = 2
-                                  , fetchBatchId = n }
+                                  , fetchBatchId = n
+                                  , fetchIds = [1,2] }
                                   | n <- reverse [1..10] ++ [11..20] ]
-                     ++ [ FetchCall "A" ["B"], FetchCall "C" ["D"] ]
+                     ++ [ FetchCall "A" ["B"] 1, FetchCall "C" ["D"] 2 ]
     fetchBatch = [ FetchStats { fetchDataSource = "batch"
                               , fetchBatchSize = 1
                               , fetchStart = 100
                               , fetchDuration = 1000 * n
                               , fetchSpace = 3
                               , fetchFailures = if n <= 3 then 1 else 0
-                              , fetchBatchId = 123 } | n <- [1..50] ]
+                              , fetchBatchId = 123
+                              , fetchIds = [fromIntegral n] } | n <- [1..50] ]
     agg (sz,bids) FetchStats{..} = (sz + fetchBatchSize, fetchBatchId:bids)
     agg _ _ = error "unexpected"
     agg' = foldl' agg (0,[])
@@ -50,4 +64,104 @@ aggregateBatches = TestCase $ do
   assertEqual
     "Grouping works as expected" expectedResultInterspersed aggInterspersedBatch
 
-tests = TestList [TestLabel "Aggregate Batches" aggregateBatches]
+
+testEnv = do
+  -- To use a data source, we need to initialize its state:
+  exstate <- ExampleDataSource.initGlobalState
+  sleepState <- mkConcurrentIOState
+
+  -- And create a StateStore object containing the states we need:
+  let st = stateSet exstate (stateSet sleepState stateEmpty)
+
+  -- Create the Env:
+  env <- initEnv st ()
+  return env{ flags = (flags env){ report = 5 } }
+
+
+fetchIdsSync :: Test
+fetchIdsSync = TestCase $ do
+  env <- testEnv
+  _ <- runHaxl  env $
+       sequence_
+       [ void $ countAardvarks "abcabc" + (length <$> listWombats 3)
+       , void $ listWombats 100
+       , void $ listWombats 99 ]
+  -- expect a single DS stat
+  (Stats stats) <- readIORef (statsRef env)
+  let
+    fetchStats = [x | x@FetchStats{} <- stats]
+  assertEqual "Only 1 batch" 1 (length fetchStats)
+
+fetchIdsBackground :: Test
+fetchIdsBackground = TestCase $ do
+  env <- testEnv
+  _ <- runHaxl  env $
+       sequence_
+       [ withLabel "short" $ sleep 1
+       , withLabel "long" $ sleep 500 ]
+
+  -- make sure that with memo'ing we still preserve the stack
+  _ <- runHaxl  env $ withLabel "base"
+    (memo (1 :: Int) $ withLabel "child" $ sleep 102)
+
+  _ <- runHaxl env $ withLabel "short_cached" $ sleep 1
+
+  -- expect a single DS stat
+  (Stats stats) <- readIORef (statsRef env)
+  (Profile p pt _) <- readIORef (profRef env)
+  let
+    keyMap =
+      HashMap.fromList [ (label, k) | ((label,_), k) <- HashMap.toList pt]
+    revMap = HashMap.fromList [(v,k) | (k,v) <- HashMap.toList pt]
+    parentMap =
+      HashMap.fromList $
+      catMaybes
+      [ case HashMap.lookup kp revMap of
+          Just (lp,_) -> Just (label, lp)
+          Nothing -> Nothing
+      | ((label,kp), _) <- HashMap.toList pt]
+    fetchMap =  HashMap.fromList [ (fid, x) | x@FetchStats{} <- stats
+                                   , fid <- fetchIds x]
+    get l = [ (prof, wasCached, fetchStat)
+            | Just key <- [HashMap.lookup l keyMap]
+            , Just prof <- [HashMap.lookup key p]
+            , ProfileFetch fid _ wasCached <- profileFetches prof
+            , Just fetchStat <- [HashMap.lookup fid fetchMap]]
+    [(short, shortWC, shortFetch)] = get "short"
+    [(long, longWC, longFetch)] = get "long"
+    [(shortCached, shortCachedWC, shortCachedFetch)] = get "short_cached"
+
+  assertEqual "3 batches" 3 (HashMap.size fetchMap)
+  assertEqual "6 labels (inc MAIN)" 6 (HashMap.size keyMap)
+
+  assertEqual "child parent is base"
+    (Just "base")
+    (HashMap.lookup "child" parentMap)
+
+  assertEqual "base parent is MAIN"
+    (Just "MAIN")
+    (HashMap.lookup "base" parentMap)
+
+  assertEqual "long parent is MAIN"
+    (Just "MAIN")
+    (HashMap.lookup "long" parentMap)
+
+  assertBool "original fetches not cached (short)" (not shortWC)
+  assertBool "original fetches not cached (long)" (not longWC)
+  assertBool "was cached short" shortCachedWC
+
+  assertEqual "one fetch short" 1 (length $ profileFetches short)
+  assertEqual "one fetch long" 1 (length $ profileFetches long)
+  assertEqual "one fetch short_cached" 1 (length $ profileFetches shortCached)
+
+  assertBool "short fetch mapped properly" (fetchDuration shortFetch < 100000)
+  assertEqual
+    "short cached fetch mapped properly"
+    (fetchDuration shortFetch)
+    (fetchDuration shortCachedFetch)
+  assertBool "long fetch was mapped properly" (fetchDuration longFetch > 100000)
+
+
+tests = TestList [ TestLabel "Aggregate Batches" aggregateBatches
+                 , TestLabel "Fetch IDs Sync" fetchIdsSync
+                 , TestLabel "Fetch IDs Background" fetchIdsBackground ]


### PR DESCRIPTION
Summary: This adds tracking of memo/fetches per label by a unique id for each. Using this we can track exactly where time was spent, and where it was shared

Reviewed By: simonmar

Differential Revision: D20792435

