### PR TITLE
fixed. compile error on ghc 8.8.3

### DIFF
--- a/Haxl/Core/Exception.hs
+++ b/Haxl/Core/Exception.hs
@@ -4,6 +4,7 @@
 -- This source code is distributed under the terms of a BSD license,
 -- found in the LICENSE file.
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -72,6 +73,9 @@ module Haxl.Core.Exception (
   tryWithRethrow,
   ) where
 
+#if __GLASGOW_HASKELL__ >= 808
+import Prelude hiding (MonadFail)
+#endif
 import Control.Exception as Exception
 import Data.Aeson
 import Data.Binary (Binary)


### PR DESCRIPTION
resolver lts-15.12 

Error 
```
haxl                       >     Ambiguous occurrence ‘MonadFail’
haxl                       >     It could refer to
haxl                       >        either ‘Prelude.MonadFail’,
haxl                       >               imported from ‘Prelude’ at Haxl/Core/Exception.hs:32:8-26
haxl                       >               (and originally defined in ‘Control.Monad.Fail’)
haxl                       >            or ‘Haxl.Core.Exception.MonadFail’,
haxl                       >               defined at Haxl/Core/Exception.hs:304:1
haxl                       >     |
haxl                       > 307 | instance Exception MonadFail where
haxl                       >     |
```