### PR TITLE
Remove mask in ConcurrentIO.hs

### DIFF
--- a/Haxl/DataSource/ConcurrentIO.hs
+++ b/Haxl/DataSource/ConcurrentIO.hs
@@ -49,7 +49,6 @@ module Haxl.DataSource.ConcurrentIO
   ) where
 
 import Control.Concurrent
-import Control.Exception as Exception
 import Control.Monad
 import qualified Data.Text as Text
 import Data.Typeable
@@ -79,5 +78,4 @@ instance
  where
   fetch _state _flags _u = BackgroundFetch $ \bfs -> do
     forM_ bfs $ \(BlockedFetch req rv) ->
-      mask $ \unmask ->
-        forkFinally (unmask (performIO req)) (putResultFromChildThread rv)
+      forkFinally (performIO req) (putResultFromChildThread rv)

--- a/tests/OutgoneFetchesTests.hs
+++ b/tests/OutgoneFetchesTests.hs
@@ -53,9 +53,9 @@ tests :: Test
 tests = TestList
   [ outgoneFetchesTest "finished" 0 $ do
       -- test that a completed datasource fetch doesn't show up in Env
-      _ <- sleep 50   -- finished
-      _ <- sleep 50   -- cached/finished
-      _ <- sleep 50   -- cached/finished
+      _ <- sleep 1  -- finished
+      _ <- sleep 1  -- cached/finished
+      _ <- sleep 1  -- cached/finished
       wombats
   , outgoneFetchesTest "unfinished" 2 $ do
       -- test that unfinished datasource fetches shows up in Env
@@ -66,7 +66,7 @@ tests = TestList
       return ()
   , outgoneFetchesTest "mixed" 2 $ do
       -- test for finished/unfinished fetches from the same datasource
-      _ <- sleep 50   -- finished
+      _ <- sleep 1   -- finished
       _ <- sleep 200  -- unfinished
       _ <- sleep 300  -- unfinished
       return ()


### PR DESCRIPTION
Summary:
I think the mask/unmask here is not required as `forkFinally` already
runs the action with async exceptions masked
(https://www.stackage.org/haddock/lts-12.26/base-4.11.1.0/Control-Concurrent.html#v:forkFinally)

I've needed to update `OutgoneFetchesTests` as well to make it more reliable

Differential Revision: D22455395

