### PR TITLE
supoprt classifying exceptions as ignored for stats

### DIFF
--- a/Haxl/Core.hs
+++ b/Haxl/Core.hs
@@ -79,6 +79,7 @@ module Haxl.Core (
   , PerformFetch(..)
   , StateKey(..)
   , SchedulerHint(..)
+  , FailureClassification(..)
 
     -- ** Result variables
   , ResultVar(..)

--- a/Haxl/Core/DataSource.hs
+++ b/Haxl/Core/DataSource.hs
@@ -27,6 +27,7 @@ module Haxl.Core.DataSource
   , BlockedFetch(..)
   , PerformFetch(..)
   , SchedulerHint(..)
+  , FailureClassification(..)
 
   -- * Result variables
   , ResultVar(..)
@@ -103,6 +104,9 @@ class (DataSourceName req, StateKey req, ShowP req) => DataSource u req where
   schedulerHint :: u -> SchedulerHint req
   schedulerHint _ = TryToBatch
 
+  classifyFailure :: u -> req a -> SomeException -> FailureClassification
+  classifyFailure _ _ _ = StandardFailure
+
 class DataSourceName (req :: * -> *) where
   -- | The name of this 'DataSource', used in tracing and stats. Must
   -- take a dummy request.
@@ -133,6 +137,11 @@ data SchedulerHint (req :: * -> *)
     -- batch multiple requests.  This is really only useful if the data source
     -- returns BackgroundFetch, otherwise requests to this data source will
     -- be performed synchronously, one at a time.
+
+-- | Hints to the stats module about how to deal with these failures
+data FailureClassification
+  = StandardFailure
+  | IgnoredForStatsFailure
 
 -- | A data source can fetch data in one of four ways.
 --

--- a/Haxl/Core/Stats.hs
+++ b/Haxl/Core/Stats.hs
@@ -134,6 +134,7 @@ data FetchStats
     , fetchDuration :: {-# UNPACK #-} !Microseconds
     , fetchSpace :: {-# UNPACK #-} !Int64
     , fetchFailures :: {-# UNPACK #-} !Int
+    , fetchIgnoredFailures :: {-# UNPACK #-} !Int
     , fetchBatchId :: {-# UNPACK #-} !Int
     , fetchIds :: [CallId]
     }
@@ -197,6 +198,7 @@ instance ToJSON FetchStats where
     , "duration" .= fetchDuration
     , "allocation" .= fetchSpace
     , "failures" .= fetchFailures
+    , "ignoredFailures" .= fetchIgnoredFailures
     , "batchid" .= fetchBatchId
     , "fetchids" .= fetchIds
     ]


### PR DESCRIPTION
Summary:
Some datasources will throw exceptions but this does not indicate a problem with the datasource itself. This can make the statistics difficult to use to track actual problems versus problems with the way the datasource is used.
Here we allow the datasource to classify some failures to be ignored by the stats collection. They are not simply ignored however - but stored in a new field `fetchIgnoredFailures`

Reviewed By: josefs

Differential Revision: D23475953

