### PR TITLE
Add time to profile

### DIFF
--- a/Haxl/Core/Stats.hs
+++ b/Haxl/Core/Stats.hs
@@ -267,8 +267,10 @@ data ProfileData = ProfileData
      -- ^ number of hits at this label
   , profileMemos :: [ProfileMemo]
      -- ^ memo and a boolean representing if it was cached at the time
+  , profileTime :: {-# UNPACK #-} !Microseconds
+     -- ^ amount of time spent in computation at this label
   }
   deriving Show
 
 emptyProfileData :: ProfileData
-emptyProfileData = ProfileData 0 [] 0 []
+emptyProfileData = ProfileData 0 [] 0 [] 0


### PR DESCRIPTION
Summary:
To track down bugs where a single label is taking a long time, but is not allocating - it is useful to store wall clock time on labels.
This is obviously only an estimate, due to the lazy nature of Haskell - but it will at least give a clue to where to start looking.

Reviewed By: anubhav94N

Differential Revision: D24083517

