### PR TITLE
Enqueue fallback results onto the completion queue

### DIFF
--- a/Haxl/Core/Fetch.hs
+++ b/Haxl/Core/Fetch.hs
@@ -155,7 +155,7 @@ stdResultVar ivar completions ref flags p =
     atomicallyOnBlocking
       (LogicBug (ReadingCompletionsFailedFetch (dataSourceName p))) $ do
       cs <- readTVar completions
-      writeTVar completions (CompleteReq r ivar allocs : cs)
+      writeTVar completions (CompleteReq (eitherToResult r) ivar allocs : cs)
     -- Decrement the counter as request has finished. Do this after updating the
     -- completions TVar so that if the scheduler is tracking what was being
     -- waited on it gets a consistent view.

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -633,7 +633,7 @@ eitherToResult (Left e) = ThrowHaxl e NilWrites
 -- the relevant computations.
 data CompleteReq u w
   = forall a . CompleteReq
-      (Either SomeException a)
+      (ResultVal a w)
       !(IVar u w a)  -- IVar because the result is cached
       {-# UNPACK #-} !Int64 -- see Note [tracking allocation in child threads]
 

--- a/Haxl/Core/Run.hs
+++ b/Haxl/Core/Run.hs
@@ -195,7 +195,7 @@ runHaxlWithWrites env@Env{..} haxl = do
                     -- pushed on the front of the completions list) and
                     -- therefore overrides it.
                   IVarEmpty cv -> do
-                    writeIORef cr (IVarFull (eitherToResult a))
+                    writeIORef cr (IVarFull a)
                     return cv
           jobs <- mapM getComplete comps
           return (foldr appendJobList JobNil jobs)


### PR DESCRIPTION
Summary:
Rather enqueue fallback results onto the completion queue, to better mimic what happens in a real fetch.
This allows `F <$> a <*> b` to fetch both a and b, even if a throws an exception.

Reviewed By: josefs

Differential Revision: D28964005

