### PR TITLE
support GHC 9.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.10.2', '8.8.4', '8.6.5', '8.4.4', '8.2.2']
+        ghc: ['8.10.2', '8.8.4', '8.6.5', '8.4.4', '8.2.2', '9.0.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/Haxl/Core/DataCache.hs
+++ b/Haxl/Core/DataCache.hs
@@ -51,7 +51,7 @@ newtype DataCache res = DataCache (HashTable TypeRep (SubCache res))
 --
 data SubCache res =
   forall req a . (Hashable (req a), Eq (req a)) =>
-       SubCache (req a -> String) (a -> String) ! (HashTable (req a) (res a))
+       SubCache (req a -> String) (a -> String) !(HashTable (req a) (res a))
        -- NB. the inner HashMap is strict, to avoid building up
        -- a chain of thunks during repeated insertions.
 


### PR DESCRIPTION
new GHC 9.0 parser fails on space before strict operator

![image](https://user-images.githubusercontent.com/18636038/138489244-9321cc80-5bdf-4496-80ef-6afb289a2f13.png)

this pull request supports GHC 9.0 by removing this space.