### PR TITLE
Build with ghc 9.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['9.0.1', '8.10.2', '8.8.4', '8.6.5', '8.4.4', '8.2.2']
+        ghc: ['9.2.2', '9.0.1', '8.10.7', '8.8.4', '8.6.5', '8.4.4', '8.2.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/Haxl/Core/Fetch.hs
+++ b/Haxl/Core/Fetch.hs
@@ -532,13 +532,15 @@ data FailureCount = FailureCount
 
 #if __GLASGOW_HASKELL__ >= 804
 instance Semigroup FailureCount where
-  (<>) = mappend
+  FailureCount s1 i1 <> FailureCount s2 i2 = FailureCount (s1+s2) (i1+i2)
 #endif
 
 instance Monoid FailureCount where
   mempty = FailureCount 0 0
+#if __GLASGOW_HASKELL__ < 804
   mappend (FailureCount s1 i1) (FailureCount s2 i2)
     = FailureCount (s1+s2) (i1+i2)
+#endif
 
 wrapFetchInStats
   :: DataSource u req

--- a/Haxl/Core/Monad.hs
+++ b/Haxl/Core/Monad.hs
@@ -775,7 +775,7 @@ toHaxlFmap f (Return i) = f <$> getIVar i
 -- Monad/Applicative instances
 
 instance Monad (GenHaxl u w) where
-  return a = GenHaxl $ \_env -> return (Done a)
+  return = pure
   GenHaxl m >>= k = GenHaxl $ \env -> do
     e <- m env
     case e of
@@ -803,7 +803,7 @@ instance Functor (GenHaxl u w) where
         return (Blocked ivar (f :<$> cont))
 
 instance Applicative (GenHaxl u w) where
-  pure = return
+  pure a = GenHaxl $ \_env -> pure (Done a)
   GenHaxl ff <*> GenHaxl aa = GenHaxl $ \env -> do
     rf <- ff env
     case rf of
@@ -831,7 +831,9 @@ instance Semigroup a => Semigroup (GenHaxl u w a) where
 
 instance Monoid a => Monoid (GenHaxl u w a) where
   mempty = pure mempty
+#if __GLASGOW_HASKELL__ < 804
   mappend = liftA2 mappend
+#endif
 
 blockedBlocked
   :: Env u w

--- a/Haxl/Core/StateStore.hs
+++ b/Haxl/Core/StateStore.hs
@@ -49,13 +49,15 @@ newtype StateStore = StateStore (Map TypeRep StateStoreData)
 
 #if __GLASGOW_HASKELL__ >= 804
 instance Semigroup StateStore where
-  (<>) = mappend
+  -- Left-biased union
+  StateStore m1 <> StateStore m2 = StateStore $ m1 <> m2
 #endif
 
 instance Monoid StateStore where
   mempty = stateEmpty
-  -- Left-biased union
+#if __GLASGOW_HASKELL__ < 804
   mappend (StateStore m1) (StateStore m2) = StateStore $ m1 <> m2
+#endif
 
 -- | Encapsulates the type of 'StateStore' data so we can have a
 -- heterogeneous collection.

--- a/haxl.cabal
+++ b/haxl.cabal
@@ -17,8 +17,10 @@ tested-with:
   GHC==8.2.2,
   GHC==8.4.4,
   GHC==8.6.5,
-  GHC==8.8.3,
-  GHC==8.10.1
+  GHC==8.8.4,
+  GHC==8.10.7
+  GHC==9.0.1
+  GHC==9.2.2
 
 description:
   Haxl is a library and EDSL for efficient scheduling of concurrent data
@@ -46,7 +48,7 @@ library
     aeson >= 0.6 && < 2.1,
     base >= 4.10 && < 5,
     binary >= 0.7 && < 0.10,
-    bytestring >= 0.9 && < 0.11,
+    bytestring >= 0.9 && < 0.12,
     containers >= 0.5 && < 0.7,
     deepseq,
     exceptions >=0.8 && <0.11,


### PR DESCRIPTION
Bumps bytestring upper bound to <0.12 and fixes some non-canonical monoid and monad definitions that don't use semigroup/applicative.