### PR TITLE
Bump aeson bound to < 2.2

### DIFF
--- a/haxl.cabal
+++ b/haxl.cabal
@@ -45,7 +45,7 @@ extra-source-files:
 library
 
   build-depends:
-    aeson >= 0.6 && < 2.1,
+    aeson >= 0.6 && < 2.2,
     base >= 4.10 && < 5,
     binary >= 0.7 && < 0.10,
     bytestring >= 0.9 && < 0.12,


### PR DESCRIPTION
Tests pass with aeson 2.1.1.0.